### PR TITLE
adding cpufrequtils

### DIFF
--- a/OrangePiRDA/scripts/lib/distributions.sh
+++ b/OrangePiRDA/scripts/lib/distributions.sh
@@ -467,7 +467,7 @@ apt-get -y update
 #rm -f "/etc/locale.gen"
 #dpkg-reconfigure --frontend noninteractive locales
 
-apt-get -y install sudo imagemagick libv4l-dev cmake bluez bluez-tools apt-transport-https man subversion python3-pip python3-setuptools gpg net-tools g++ libjpeg-dev usbutils curl dosfstools curl xz-utils iw rfkill ifupdown wpasupplicant openssh-server rsync u-boot-tools vim parted network-manager git autoconf gcc libtool ntp libsysfs-dev pkg-config libdrm-dev xutils-dev alsa-utils acl crda
+apt-get -y install sudo imagemagick libv4l-dev cmake bluez bluez-tools apt-transport-https man subversion python3-pip python3-setuptools gpg net-tools g++ libjpeg-dev usbutils curl dosfstools curl xz-utils iw rfkill ifupdown wpasupplicant openssh-server rsync u-boot-tools vim parted network-manager git autoconf gcc libtool ntp libsysfs-dev pkg-config libdrm-dev xutils-dev alsa-utils acl crda cpufrequtils
 apt-get -y install $EXTRADEBS
 
 pip3 install spidev


### PR DESCRIPTION
Adding to cpufrequtils to image, now were able to control the cpu over cpufrequtils .

root@orangepii96:~# cpufreq-info
cpufrequtils 008: cpufreq-info (C) Dominik Brodowski 2004-2009 Report errors and bugs to cpufreq@vger.kernel.org, please. analyzing CPU 0:
  driver: rda
  CPUs which run at the same hardware frequency: 0
  CPUs which need to have their frequency coordinated by software: 0
  maximum transition latency: 300 us.
  hardware limits: 329 MHz - 1.19 GHz
  available frequency steps: 329 MHz, 395 MHz, 494 MHz, 988 MHz
  available cpufreq governors: ondemand, interactive, performance
  current policy: frequency should be within 329 MHz and 988 MHz.
                  The governor "performance" may decide which speed to use
                  within this range.
  current CPU frequency is 988 MHz (asserted by call to hardware).
  cpufreq stats: 329 MHz:3.69%, 395 MHz:0.08%, 494 MHz:0.04%, 988 MHz:96.20%  (53)